### PR TITLE
update to symfony 3.4 from 3.1 when using rothenberg to install a pro…

### DIFF
--- a/resources/composer.json.php
+++ b/resources/composer.json.php
@@ -27,10 +27,18 @@ if (($argv[2] ?? 'app') == 'app') {
     $composerJson["autoload-dev"]["psr-4"]["AppBundle\\Tests\\Units\\"] = "./tests/units/src/AppBundle";
     $composerJson["autoload-dev"]["psr-4"]["AppBundle\\Tests\\Functionals\\"] = "./tests/functionals/bootstrap";
 
-    $composerJson["require"]["symfony/symfony"] = "3.1.*";
-    $composerJson["require"]["symfony/console"] = "3.1.*";
-    $composerJson["require"]["sensio/distribution-bundle"] = "^5.0";
-    $composerJson["require"]["sensio/framework-extra-bundle"] = "3.0.*";
+
+    if( !isset( $composerJson["require"]["symfony/symfony"] )) {
+	    $composerJson["require"]["symfony/symfony"] = "3.4.*";
+    }
+
+    if( !isset( $composerJson["require"]["sensio/framework-extra-bundle"] )) {
+        $composerJson["require"]["sensio/framework-extra-bundle"] = "5.*";
+    }
+
+    if( !isset( $composerJson["require"]["sensio/distribution-bundle"] )) {
+        $composerJson["require"]["sensio/distribution-bundle"] = "5.*";
+    }
 
     $composerJson["require-dev"]["behat/behat"] = "~3.2";
     $composerJson["require-dev"]["behat/symfony2-extension"] = "^2.1";

--- a/tests/oracles/install/app/composer.json
+++ b/tests/oracles/install/app/composer.json
@@ -21,10 +21,9 @@
     },
     "require": {
         "php": ">=7.0.0",
-        "symfony/symfony": "3.1.*",
-        "symfony/console": "3.1.*",
-        "sensio/distribution-bundle": "^5.0",
-        "sensio/framework-extra-bundle": "3.0.*"
+        "symfony/symfony": "3.4.*",
+        "sensio/framework-extra-bundle": "5.*",
+        "sensio/distribution-bundle": "5.*"
     },
     "extra": {
         "symfony-app-dir": "./app",


### PR DESCRIPTION
- If applied, this commit will allow rothenberg to install symfony 3.4 by default with updated sensio packages.

- This change is made to be updated to the last version of symfony, improve functionalities and security