### PR TITLE
Add COMPOSER_CACHE creation rules 

### DIFF
--- a/resources/env/app.mk
+++ b/resources/env/app.mk
@@ -48,6 +48,9 @@ bin/docker-compose: | bin/. .env
 $(NPM_CACHE):
 	$(MKDIR) $@
 
+$(COMPOSER_CACHE):
+	$(MKDIR) $(COMPOSER_CACHE)
+
 .env: env/.env.dist $(firstword $(MAKEFILE_LIST)) $(SSH_KEY) | $(COMPOSER_CACHE) $(NPM_CACHE)
 	$(RM) var/cache
 	if [ -x bin/docker-compose -a -f .env ]; then bin/docker-compose down; fi

--- a/resources/env/bundle.mk
+++ b/resources/env/bundle.mk
@@ -18,5 +18,8 @@ tmp:
 bin/docker-compose: | bin/. .env
 	$(call install,$@)
 
+$(COMPOSER_CACHE):
+	$(MKDIR) $(COMPOSER_CACHE)
+
 .env: env/.env.dist $(SSH_KEY) | $(COMPOSER_CACHE)
 	export ETC=$(ETC) USER_HOME=$(HOME) USER_ID=$(USER_ID) SYMFONY_ENV=$(SYMFONY_ENV) SSH_KEY=$(SSH_KEY) COMPOSER_CACHE=$(COMPOSER_CACHE) ENV=$(ENV) SYMFONY_DEBUG=$(SYMFONY_DEBUG) && $(call export-file,$<,$@)

--- a/tests/oracles/install/app/env/Makefile
+++ b/tests/oracles/install/app/env/Makefile
@@ -48,6 +48,9 @@ bin/docker-compose: | bin/. .env
 $(NPM_CACHE):
 	$(MKDIR) $@
 
+$(COMPOSER_CACHE):
+	$(MKDIR) $(COMPOSER_CACHE)
+
 .env: env/.env.dist $(firstword $(MAKEFILE_LIST)) $(SSH_KEY) | $(COMPOSER_CACHE) $(NPM_CACHE)
 	$(RM) var/cache
 	if [ -x bin/docker-compose -a -f .env ]; then bin/docker-compose down; fi

--- a/tests/oracles/install/bundle/env/Makefile
+++ b/tests/oracles/install/bundle/env/Makefile
@@ -18,5 +18,8 @@ tmp:
 bin/docker-compose: | bin/. .env
 	$(call install,$@)
 
+$(COMPOSER_CACHE):
+	$(MKDIR) $(COMPOSER_CACHE)
+
 .env: env/.env.dist $(SSH_KEY) | $(COMPOSER_CACHE)
 	export ETC=$(ETC) USER_HOME=$(HOME) USER_ID=$(USER_ID) SYMFONY_ENV=$(SYMFONY_ENV) SSH_KEY=$(SSH_KEY) COMPOSER_CACHE=$(COMPOSER_CACHE) ENV=$(ENV) SYMFONY_DEBUG=$(SYMFONY_DEBUG) && $(call export-file,$<,$@)


### PR DESCRIPTION
If applied, this commit will ensure that rothenberg creates the composer_cache directory before even using it. This change was made to prevent errors on running 'make install' command with no composer cache directory created.