### PR TITLE
Remove inception for bin/console to composer docker volumes

### DIFF
--- a/resources/docker-compose.app.yml
+++ b/resources/docker-compose.app.yml
@@ -56,7 +56,6 @@ services:
             - ./composer.passwd:/etc/passwd
             - .:/src
             - ${COMPOSER_CACHE}:/.composer
-            - ./app/console.php:/src/bin/console
         environment:
             - COMPOSER_CACHE_DIR=/.composer
             - COMPOSER_ALLOW_SUPERUSER=1

--- a/resources/docker-compose.bundle.yml
+++ b/resources/docker-compose.bundle.yml
@@ -22,7 +22,6 @@ services:
             - ${SSH_KEY}:${SSH_KEY}:ro
             - ./composer.passwd:/etc/passwd
             - .:/src
-            - ./app/console.php:/src/bin/console
             - ${COMPOSER_CACHE}:/.composer
         environment:
             - COMPOSER_CACHE_DIR=/.composer

--- a/tests/oracles/install/app/docker-compose.yml
+++ b/tests/oracles/install/app/docker-compose.yml
@@ -56,7 +56,6 @@ services:
             - ./composer.passwd:/etc/passwd
             - .:/src
             - ${COMPOSER_CACHE}:/.composer
-            - ./app/console.php:/src/bin/console
         environment:
             - COMPOSER_CACHE_DIR=/.composer
             - COMPOSER_ALLOW_SUPERUSER=1

--- a/tests/oracles/install/bundle/docker-compose.yml
+++ b/tests/oracles/install/bundle/docker-compose.yml
@@ -22,7 +22,6 @@ services:
             - ${SSH_KEY}:${SSH_KEY}:ro
             - ./composer.passwd:/etc/passwd
             - .:/src
-            - ./app/console.php:/src/bin/console
             - ${COMPOSER_CACHE}:/.composer
         environment:
             - COMPOSER_CACHE_DIR=/.composer


### PR DESCRIPTION
Fix for #27.

It appears that `bin/console` file is recreated by docker when rothenberg is updated. 
I just remove the `./app/console.php:/src/bin/console` volume rule of the composer image to avoid that. 